### PR TITLE
Add pkgs.perl flake.nix

### DIFF
--- a/benchmark/flake.nix
+++ b/benchmark/flake.nix
@@ -679,6 +679,7 @@
               pkgs.elfutils.out
               pkgs.openssl.dev
               pkgs.openssl.out
+              pkgs.perl
 
               # Reproducibility tester
               pkgs.icdiff


### PR DESCRIPTION
Fixes `sh: line 1: perl: command not found`